### PR TITLE
Update definitions for v8 - Observability and Quality of Service

### DIFF
--- a/definitions.yaml
+++ b/definitions.yaml
@@ -631,3 +631,16 @@ hierarchy:
           maturitySignals: >
             Experiments and data analysis systematically test and validate assumptions.
             Experiments are used to genuinely acquire new knowledge.
+        - ID: 5-quality-of-service
+          Name: Quality of Service
+          Definition: >
+            The cummination of logging > Alerting > Incident Management > SLIs > SLOs and Product Metrics
+            into a proactive approach approach where service health trends inform decisions.
+          Purpose: >
+            Maintain or improve service reliability and user experience over time,
+            anticipating issues before customers notice. Moves SLIs/SLOs from “measurement only”
+            to a driver for decision-making.
+          maturitySignals: >
+            High-stakes company events proceed without restrictions on deployments.
+            Roadmap and weekly items are regularly driven by service health insights.
+            Degradation is detected before customer report it.

--- a/definitions.yaml
+++ b/definitions.yaml
@@ -631,15 +631,3 @@ hierarchy:
           maturitySignals: >
             Experiments and data analysis systematically test and validate assumptions.
             Experiments are used to genuinely acquire new knowledge.
-        - ID: 5-chaos-engineering
-          Name: Chaos / Game Days
-          Definition: >
-            By regularly subjecting the product to controlled chaos, the team can strengthen the system's robustness,
-            improve incident response capabilities, and enhance overall system reliability.
-          Purpose: >
-            During chaos/game days, the team simulates real-world failure scenarios, such as service outages or
-            network disruptions, to identify vulnerabilities, assess the system's response, and fine-tune incident
-            response processes.
-          maturitySignals: >
-            My product team regularly conducts chaos/game days to proactively test and validate the system's
-            resilience and readiness for unexpected scenarios.

--- a/definitions.yaml
+++ b/definitions.yaml
@@ -112,17 +112,21 @@ hierarchy:
             Optimised and managed for high performance, scalability and availability. The team can
             quickly access production log files and data to assist with troubleshooting issues.
 
-        - ID: 1-observability
-          Name: Observability
+          #  Old id was 1-observability
+        - ID: 1-logging-monitoring
+          Name: Logging & Monitoring
           Definition: >
-            Ability to debug, troubleshoot and monitor normal and abnormal system behaviour.
-            Curated patterns and tooling for the collection, storage, querying and aggregation of
-            system data
+            Ability to debug, troubleshoot and monitor normal and abnormal
+            system behaviour. Curated patterns and tooling for the collection,
+            storage, querying and aggregation of system data
           Purpose: >
-            It provides comprehensive visibility into the system's health, performance, and logs,
-            allowing for timely detection and resolution of issues.
+            High level awareness of production health and adequate tooling and
+            instrumentation to investigate issues.
           maturitySignals: >
-            An opinionated operational health dashboard familiar to the team.
+            Dashbpards are in place for core signals such as latency, errors,
+            throughput, and ssaturation. Structured logs are implemented for
+            all components according to a unified standard.
+            We have basic alerting in place for latency and error rates.
 
         - ID: 1-operating-rhythms
           Name: Operating Rhythms
@@ -578,13 +582,14 @@ hierarchy:
       name: Flow
       description: >-
         What does the team need for a thriving innovation culture
-        while enjoying high throughput and Industry leading quality of service?<br />
+        while enjoying high throughput and Industry leading quality of service?
         Maturity here is marked by being able to work productively
         over long periods while maintaining, if not increasing,
         customer trust. Governance and controls for security, privacy, cost, and
-        disaster recovery are in place and regularly exercised. Teams have enough space to run multiple experiments in
-        parallel and proactively learn about system behaviour through tools such as chaos engineering.
-        Hackathons and Game days foster innovation by quickly acting on ideas discovered.
+        disaster recovery are in place and regularly exercised. Teams have
+        enough space to run multiple experiments in parallel. A quality culture
+        across teams upholds not just the quality of new work, but ensures
+        services reliability and performance are meeting customer expectations.
 
       needs:
         - ID: 5-generative-culture
@@ -604,6 +609,7 @@ hierarchy:
             curiosity. Quality, reliability, and availability are embraced as a team responsibility, not siloed.
             Novel ideas are welcomed and implemented, teams have both the permission and mechanisms to explore
             improvements.
+
         - ID: 5-governance
           Name: Governance & DR
           Definition: >
@@ -631,16 +637,20 @@ hierarchy:
           maturitySignals: >
             Experiments and data analysis systematically test and validate assumptions.
             Experiments are used to genuinely acquire new knowledge.
+
         - ID: 5-quality-of-service
           Name: Quality of Service
           Definition: >
-            The cummination of logging > Alerting > Incident Management > SLIs > SLOs and Product Metrics
-            into a proactive approach approach where service health trends inform decisions.
+            The cummination of logging > Alerting > Incident Management >
+            SLIs > SLOs and Product Metrics into a proactive approach
+            where service health trends inform decisions.
           Purpose: >
-            Maintain or improve service reliability and user experience over time,
-            anticipating issues before customers notice. Moves SLIs/SLOs from “measurement only”
-            to a driver for decision-making.
+            Maintain or improve service reliability and user experience
+            over time, anticipating issues before customers notice.
+            Moves SLIs/SLOs from “measurement only” to a driver for
+            decision-making.
           maturitySignals: >
-            High-stakes company events proceed without restrictions on deployments.
-            Roadmap and weekly items are regularly driven by service health insights.
-            Degradation is detected before customer report it.
+            High-stakes company events proceed without restrictions
+            on deployments. Roadmap and weekly items are regularly driven by
+            service health insights. Degradation is detected before customers
+            report it.

--- a/definitions.yaml
+++ b/definitions.yaml
@@ -319,15 +319,21 @@ hierarchy:
         - ID: 2-alerting
           Name: Alerting
           Definition: >
-            The team has implemented an intelligent alerting mechanism that monitors key metrics in agreed thresholds
-            across request rates, errors and latency. Scheduled tests regularly check the primary service flows or user
-            actions for availability. When detecting abnormal system behaviour, the team is alerted before the customer
-            or stakeholder reports an issue.
+            Alerting is trusted to inform the team of abnormal system behaviour.
+            The team has implemented an intelligent alerting mechanism that
+            monitors key metrics in agreed thresholds across request rates,
+            errors and latency. Scheduled tests regularly
+            check the primary service flows or user actions for availability.
+            Distributed tracing and correlation enable effective
+            troubleshooting and debugging.
           Purpose: >
-            To ensure timely detection and response to abnormal system behaviour, preventing potential issues
-            from escalating.
+            To ensure timely detection and response to abnormal system
+            behaviour, preventing potential issues from escalating.
           maturitySignals: >-
-            The team normally detect and raise an issue before the customer or stakeholder reports an issue.
+            The team normally detect and raise an issue before the customer
+            or stakeholder reports an issue.
+            Distributed tracing is enabled for all components.
+            There is correlation across signals for faster debugging.
         - ID: 2-deployment-solutions
           Name: Deployment Solutions
           Definition: >
@@ -438,18 +444,24 @@ hierarchy:
             Incidents are raised, and resolved regularly and without panic. Incidents are lead by a variety of
             individuals. Interesting incidents are investigated and knowledge is shared with leadership
             and other teams.
-        - ID: 3-quality-of-service
-          Name: SLIs, SLOs
+          #  Old id was 3-quality-of-service
+        - ID: 3-service-metrics
+          Name: Service Metrics
           Definition: >
-            There are clear service level objectives (SLOs) and service level indicators (SLIs) that help measure
-            performance, ensuring the product consistently meets the defined quality and reliability standards.
-            These SLOs and SLIs define synthetic tests of primary workflows and key metrics, such as response time,
-            availability, and error rates.
+            Maintaining a clear view of service health from the user's
+            perspective. Key user journies and actions are defined and measured.
+            Service level objectives (SLOs), and service level indicators (SLIs)
+            are reviewed at regular intervals. These SLOs and SLIs define
+            synthetic tests of primary workflows and key metrics, such as
+            response time, availability, and error rates.
           Purpose: >
-            The team can monitor and continuously improve the product's performance against established benchmarks
-            and commitments made to customers.
+            The team can monitor the product's performance against established
+            benchmarks or expectations of stakeholders and users.
           maturitySignals: >
-            The team is aware of a baseline level of performance for their key services over the past 3-6 months.
+            The team is aware of a baseline level of performance for their key
+            services over the past 3-6 months.
+            Noisy errors and alerts are actively managed and reduced.
+
         - ID: 3-apis-sdks
           Name: APIs & SDKs
           Definition: >
@@ -641,10 +653,11 @@ hierarchy:
         - ID: 5-quality-of-service
           Name: Quality of Service
           Definition: >
-            The cummination of logging > Alerting > Incident Management >
+            The culmination of logging > Alerting > Incident Management >
             SLIs > SLOs and Product Metrics into a proactive approach
-            where service health trends inform decisions.
+            where service health trends inform decisions alongside new features.
           Purpose: >
+            Balancing value generation with value protection.
             Maintain or improve service reliability and user experience
             over time, anticipating issues before customers notice.
             Moves SLIs/SLOs from “measurement only” to a driver for


### PR DESCRIPTION
Made the following changes to:

**🚮 Removed**
5-chaos-engineering

**➕ Added**
5-quality-of-service

**✍️ Edited**

 **1-observability**:  Renamed to 1-logging-monitoring, plus some edits to definition.
**2-Alerting**: Edits to definition.
**3-quality-of-service** Renamed to 3-service-metrics, plus some edits within.

Background context for changes:
[Observability - suggested revisions to HoEN](https://www.wiresuncrossed.co.nz/post/hoen-suggestions-for-observibility)

### Diagram

```mermaid
flowchart TD
  L1Obs["Basic Needs — Logging & Monitoring"]
  L2Alert["Managed Work — Alerting"]

  IM["Effective Ownership — Incident Management"]
  SLIs["Effective Ownership — Service Metrics"]

  PM["Sustainability — Product Metrics"]

  HD["Flow — Hypothesis Driven Development"]
  QoS["Flow — Quality of Service"]

  L1Obs -->|Detect issues early| L2Alert
  L2Alert -->|Respond effectively| IM
  L2Alert --> SLIs

  IM --> PM
  SLIs --> |Establish Baselines| PM

  PM --> HD
  PM --> QoS
```